### PR TITLE
Update dependency definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "grunt-lib-contrib": "0.3.x | 0.4.x"
+    "grunt-lib-contrib": "0.3.x || 0.4.x"
   },
   "devDependencies": {
     "grunt": "*"


### PR DESCRIPTION
Update `grunt-lib-contrib` dependency definition as described in docmentation [GitHub](https://npmjs.org/doc/json.html#dependencies).

Setup of `node v0.8.19` and  `npm 1.2.10` throws error

```
npm ERR! Error: No compatible version found: grunt-lib-contrib@'>=0.3.0- <0.4.0- >=0.4.0- <0.5.0-'
npm ERR! Valid install targets:
npm ERR! ["0.3.0","0.3.1","0.4.0","0.5.1","0.5.2"]
```
