### PR TITLE
Can scan pattern of files

### DIFF
--- a/tasks/jsduck.js
+++ b/tasks/jsduck.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
         var helpers = require('grunt-lib-contrib').init(grunt),
             cmd = 'jsduck',
             options = helpers.options(this),
-            src = this.hasOwnProperty('file') ? this.file.src : this.data.src,
+            src = this.filesSrc,
             dest = outDir || (this.hasOwnProperty('dest') ? this.file.dest : this.data.dest),
             args,
             done = this.async(),


### PR DESCRIPTION
Currently, it's impossible to ask `grunt-jsduck` to scan a list of files given by a pattern
For example the following config in `Gruntfile.js` doesn't work:

```
        jsduck: {
            main: {
                src: ['./Resources/public/js/**/*.js'],
                dest: 'build/api/jsduck'
            }
        }
```

With this PR, this config now works. The fix has been inspired by the code from `grunt-jsdoc`
